### PR TITLE
Add notes queries to item and record search (fix #88)

### DIFF
--- a/src/Api/Adapter/DatascribeItemAdapter.php
+++ b/src/Api/Adapter/DatascribeItemAdapter.php
@@ -55,6 +55,32 @@ class DatascribeItemAdapter extends AbstractEntityAdapter
                 $this->createNamedParameter($qb, $query['item_id']))
             );
         }
+        if (isset($query['item_transcriber_notes_status'])) {
+            if ('is_not_null' === $query['item_transcriber_notes_status']) {
+                $qb->andWhere($qb->expr()->isNotNull('omeka_root.transcriberNotes'));
+            } elseif ('is_null'=== $query['item_transcriber_notes_status']) {
+                $qb->andWhere($qb->expr()->isNull('omeka_root.transcriberNotes'));
+            }
+        }
+        if (isset($query['item_reviewer_notes_status'])) {
+            if ('is_not_null' === $query['item_reviewer_notes_status']) {
+                $qb->andWhere($qb->expr()->isNotNull('omeka_root.reviewerNotes'));
+            } elseif ('is_null'=== $query['item_reviewer_notes_status']) {
+                $qb->andWhere($qb->expr()->isNull('omeka_root.reviewerNotes'));
+            }
+        }
+        if (isset($query['item_transcriber_notes']) && '' !== trim($query['item_transcriber_notes'])) {
+            $qb->andWhere($qb->expr()->like(
+                'omeka_root.transcriberNotes',
+                $this->createNamedParameter($qb, '%' . $query['item_transcriber_notes'] . '%'))
+            );
+        }
+        if (isset($query['item_reviewer_notes']) && '' !== trim($query['item_reviewer_notes'])) {
+            $qb->andWhere($qb->expr()->like(
+                'omeka_root.reviewerNotes',
+                $this->createNamedParameter($qb, '%' . $query['item_reviewer_notes'] . '%'))
+            );
+        }
         if (isset($query['resource_class_id'])) {
             $classes = $query['resource_class_id'];
             if (!is_array($classes)) {

--- a/src/Api/Adapter/DatascribeRecordAdapter.php
+++ b/src/Api/Adapter/DatascribeRecordAdapter.php
@@ -74,6 +74,32 @@ class DatascribeRecordAdapter extends AbstractEntityAdapter
                 $this->createNamedParameter($qb, $query['datascribe_item_id']))
             );
         }
+        if (isset($query['transcriber_notes_status'])) {
+            if ('is_not_null' === $query['transcriber_notes_status']) {
+                $qb->andWhere($qb->expr()->isNotNull('omeka_root.transcriberNotes'));
+            } elseif ('is_null'=== $query['transcriber_notes_status']) {
+                $qb->andWhere($qb->expr()->isNull('omeka_root.transcriberNotes'));
+            }
+        }
+        if (isset($query['reviewer_notes_status'])) {
+            if ('is_not_null' === $query['reviewer_notes_status']) {
+                $qb->andWhere($qb->expr()->isNotNull('omeka_root.reviewerNotes'));
+            } elseif ('is_null'=== $query['reviewer_notes_status']) {
+                $qb->andWhere($qb->expr()->isNull('omeka_root.reviewerNotes'));
+            }
+        }
+        if (isset($query['transcriber_notes']) && '' !== trim($query['transcriber_notes'])) {
+            $qb->andWhere($qb->expr()->like(
+                'omeka_root.transcriberNotes',
+                $this->createNamedParameter($qb, '%' . $query['transcriber_notes'] . '%'))
+            );
+        }
+        if (isset($query['reviewer_notes']) && '' !== trim($query['reviewer_notes'])) {
+            $qb->andWhere($qb->expr()->like(
+                'omeka_root.reviewerNotes',
+                $this->createNamedParameter($qb, '%' . $query['reviewer_notes'] . '%'))
+            );
+        }
         if (isset($query['needs_review'])) {
             if (in_array($query['needs_review'], [true, 1, '1'], true)) {
                 $qb->andWhere($qb->expr()->eq('omeka_root.needsReview', 1));

--- a/src/Form/ItemSearchForm.php
+++ b/src/Form/ItemSearchForm.php
@@ -98,5 +98,51 @@ class ItemSearchForm extends AbstractForm
                 'data-placeholder' => 'Select status', // @translate
             ],
         ]);
+        $this->add([
+            'type' => 'select',
+            'name' => 'item_transcriber_notes_status',
+            'options' => [
+                'label' => 'Transcriber notes status', // @translate
+                'empty_option' => '',
+                'value_options' => [
+                    'is_not_null' => 'Has notes', // @translate
+                    'is_null' => 'Has no notes', // @translate
+                ],
+            ],
+            'attributes' => [
+                'class' => 'chosen-select',
+                'data-placeholder' => 'Select status', // @translate
+            ],
+        ]);
+        $this->add([
+            'type' => 'select',
+            'name' => 'item_reviewer_notes_status',
+            'options' => [
+                'label' => 'Reviewer notes status', // @translate
+                'empty_option' => '',
+                'value_options' => [
+                    'is_not_null' => 'Has notes', // @translate
+                    'is_null' => 'Has no notes', // @translate
+                ],
+            ],
+            'attributes' => [
+                'class' => 'chosen-select',
+                'data-placeholder' => 'Select status', // @translate
+            ],
+        ]);
+        $this->add([
+            'type' => 'text',
+            'name' => 'item_transcriber_notes',
+            'options' => [
+                'label' => 'Search transcriber notes', // @translate
+            ],
+        ]);
+        $this->add([
+            'type' => 'text',
+            'name' => 'item_reviewer_notes',
+            'options' => [
+                'label' => 'Search reviewer notes', // @translate
+            ],
+        ]);
     }
 }

--- a/src/Form/RecordSearchForm.php
+++ b/src/Form/RecordSearchForm.php
@@ -93,5 +93,52 @@ class RecordSearchForm extends AbstractForm
                 'data-placeholder' => 'Select user', // @translate
             ],
         ]);
+
+        $this->add([
+            'type' => 'select',
+            'name' => 'transcriber_notes_status',
+            'options' => [
+                'label' => 'Transcriber notes status', // @translate
+                'empty_option' => '',
+                'value_options' => [
+                    'is_not_null' => 'Has notes', // @translate
+                    'is_null' => 'Has no notes', // @translate
+                ],
+            ],
+            'attributes' => [
+                'class' => 'chosen-select',
+                'data-placeholder' => 'Select status', // @translate
+            ],
+        ]);
+        $this->add([
+            'type' => 'select',
+            'name' => 'reviewer_notes_status',
+            'options' => [
+                'label' => 'Reviewer notes status', // @translate
+                'empty_option' => '',
+                'value_options' => [
+                    'is_not_null' => 'Has notes', // @translate
+                    'is_null' => 'Has no notes', // @translate
+                ],
+            ],
+            'attributes' => [
+                'class' => 'chosen-select',
+                'data-placeholder' => 'Select status', // @translate
+            ],
+        ]);
+        $this->add([
+            'type' => 'text',
+            'name' => 'transcriber_notes',
+            'options' => [
+                'label' => 'Search transcriber notes', // @translate
+            ],
+        ]);
+        $this->add([
+            'type' => 'text',
+            'name' => 'reviewer_notes',
+            'options' => [
+                'label' => 'Search reviewer notes', // @translate
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
This branch adds several ways to search transcriber and reviewer notes in the advanced item and record search. A user can now search the following:

- Transcriber notes status: select from "has notes" and "has no notes"
- Reviewer notes status: select from "has notes" and "has no notes"
- Search transcriber notes: text input
- Search reviewer notes: text input